### PR TITLE
Fixed Filter option going incorrectly

### DIFF
--- a/src/Plugin/Filter/MentionsFilter.php
+++ b/src/Plugin/Filter/MentionsFilter.php
@@ -201,7 +201,7 @@ class MentionsFilter extends FilterBase implements ContainerFactoryPluginInterfa
 
   public function filter_mentions_structure($text) {
       $results = array();
-      foreach($this->mentionFilters as $filter) {
+      foreach($this->mentionFilters as $filter => $filter_index) {
         $results[] = $this->mentions_get_mentions($text, $filter);
       }
       


### PR DESCRIPTION
Please verify Patch.

In that filter name is not passed to mentions_get_mentions function instead id passed.

